### PR TITLE
Fix an improper initialization bug

### DIFF
--- a/src/TinyGPS++.cpp
+++ b/src/TinyGPS++.cpp
@@ -257,6 +257,11 @@ bool TinyGPSPlus::endOfTermHandler()
 
     else
     {
+      if (curSentenceType == GPS_SENTENCE_GPRMC) {
+          // Bad checksum in GPRMC sentence, reset optional variables
+          //   to prevent meshtastic-device issue #863
+          course.newval = speed.newval = 0;
+      }
       ++failedChecksumCount;
     }
 


### PR DESCRIPTION
Improper data hygiene causes junk data to be presented as valid in some circumstances.

**Background:**
- each `GPSDatum` has two value variables: temporary (`newval`) and final (`val`)
- when a GPS sentence is parsed, its elements are first read into temporary variables (`set()`)
- at the end of the sentence, a checksum verification is performed
- if verified OK, the temp vars are copied (`commit()`) to final vars, which are presented to client;
- however, if verification fails, the temp vars are not committed - **this is where the bug occurs**

**Problem:**
After a checksum failure, the temp vars are left containing potentially junk data, relying only on the assumption that they will be overwritten with good data when the next sentence is parsed. However, **this assumption is broken in the case of optional fields**, like many of the fields in the `GPRMC` sentence are. If a field is empty, **nothing is written** in the respective temp var anymore; and so the previous (junk) value is carried forward and committed as part of the valid set.

**Example:** if a corrupt GPRMC message puts a junk value in `course.newval` , a subsequent valid GPRMC message with an empty field 8 will result in the junk value becoming committed to `course.val` - causing issue meshtastic/Meshtastic-device/issues/863

The fix is to properly reset the temp vars associated with optional fields.