### PR TITLE
Support generic xxRMC and xxGGA terms

### DIFF
--- a/src/TinyGPS++.cpp
+++ b/src/TinyGPS++.cpp
@@ -31,12 +31,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define _GPGSVterm   "GPGSV"
 #define _GPRMCterm   "GPRMC"
 #define _GPGGAterm   "GPGGA"
-#define _GNRMCterm   "GNRMC"
-#define _GNGGAterm   "GNGGA"
-#define _GARMCterm   "GARMC"
-#define _GAGGAterm   "GAGGA"
-#define _GLRMCterm   "GLRMC"
-#define _GLGGAterm   "GLGGA"
 
 TinyGPSPlus::TinyGPSPlus()
   :  parity(0)
@@ -302,11 +296,12 @@ bool TinyGPSPlus::endOfTermHandler(bool termIsNotEmpty)
   }
 
   // the first term determines the sentence type
+  // xxRMC/xxGGA where xx = NMEA Talker ID (GP=GPS, GL=GLONASS, GA=Galileo, GB/BD=Beidou, GN=GNSS)
   if (curTermNumber == 0)
   {
-    if (!strcmp(term, _GPRMCterm) || !strcmp(term, _GNRMCterm) || !strcmp(term, _GARMCterm) || !strcmp(term, _GLRMCterm))
+    if (strlen(term) == 5 && !strncmp(term+2, "RMC", 3))
       curSentenceType = GPS_SENTENCE_GPRMC;
-    else if (!strcmp(term, _GPGGAterm) || !strcmp(term, _GNGGAterm) || !strcmp(term, _GAGGAterm) || !strcmp(term, _GLRMCterm))
+    else if (strlen(term) == 5 && !strncmp(term+2, "GGA", 3))
       curSentenceType = GPS_SENTENCE_GPGGA;
     else if (!strcmp(term, _GPGSVterm))
       curSentenceType = GPS_SENTENCE_GPGSV;


### PR DESCRIPTION
Multi-GNSS modules will likely emit GNGGA and GNRMC messages when systems are enabled alongside other systems, however if a single system is the only one enabled it may only emit `xxGGA` and `xxRMC` terms (where `xx` is the Talker ID) which currently may not be parsed.

- Add support for generic parsing of `xxRMC`/`xxGGA` messages (where `xx` is the NMEA Talker ID)

| Talker ID | System  |
|-----------|---------|
| GP        | GPS     |
| BD/GB     | Beideu  |
| GL        | GLONASS |
| GA        | Galileo |
| GN        | GNSS    |

**Testing**

With a module configured with only BDS enabled and is only emitting BDGGA and BDRMC terms:

```
...
$BDGGA,163448.000,xxx,S,yyy,E,1,09,1.0,54.7,M,0.0,M,,*54
$BDRMC,163448.000,A,xxx,S,yyy,E,0.00,93.93,130424,,,A*58
$BDGGA,163449.000,xxx,S,yyy,E,1,09,1.0,54.7,M,0.0,M,,*54
$BDRMC,163449.000,A,xxx,S,yyy,E,0.00,93.93,130424,,,A*58
$BDGGA,163450.000,xxx,S,yyy,E,1,09,1.0,54.6,M,0.0,M,,*59
$BDRMC,163450.000,A,xxx,S,yyy,E,0.00,93.93,130424,,,A*54
...
```

*Before Change*

TinyGPS++ is unable to process the messages and extact any location/time information

```
DEBUG | ??:??:?? 0 Enter state: BOOT
DEBUG | ??:??:?? 0 [GPS] Probing for GPS at 9600 
INFO  | ??:??:?? 0 [GPS] ATGM336H GNSS init succeeded, using ATGM336H Module
DEBUG | ??:??:?? 0 [GPS] publishing pos@0:2, hasVal=0, Sats=0, GPSlock=0
DEBUG | ??:??:?? 0 [GPS] No GPS lock
DEBUG | ??:??:?? 0 [GPS] onGPSChanged() pos@0, time=0, lat=0, lon=0, alt=0
INFO  | ??:??:?? 0 [GPS] updatePosition LOCAL pos@0, time=0, latI=0, lonI=0, alt=0
DEBUG | ??:??:?? 0 [GPS] Setting local position: latitude=0, longitude=0, time=0
DEBUG | ??:??:?? 0 [GPS] Node status update: 0 online, 2 total
...
```

*After Change*

TinyGPS++ process the terms and extracts the location/time information

```
DEBUG | ??:??:?? 0 Enter state: BOOT
DEBUG | ??:??:?? 0 [GPS] Probing for GPS at 9600 
INFO  | ??:??:?? 0 [GPS] ATGM336H GNSS init succeeded, using ATGM336H Module
WARN  | ??:??:?? 1 [GPS] SOME data is TOO OLD: LOC 0, TIME 0, DATE 4294967295
DEBUG | ??:??:?? 1 [GPS] publishing pos@0:2, hasVal=0, Sats=0, GPSlock=1
DEBUG | ??:??:?? 1 [GPS] No GPS lock
DEBUG | ??:??:?? 1 [GPS] onGPSChanged() pos@0, time=0, lat=0, lon=0, alt=0
INFO  | ??:??:?? 1 [GPS] updatePosition LOCAL pos@0, time=0, latI=0, lonI=0, alt=0
DEBUG | ??:??:?? 1 [GPS] Setting local position: latitude=0, longitude=0, time=0
DEBUG | ??:??:?? 1 [GPS] NMEA GPS time 2024-04-13 16:41:44
DEBUG | ??:??:?? 1 [GPS] Upgrading time to quality 4
DEBUG | 16:41:44 1 [GPS] Read RTC time as 1713026504
DEBUG | 16:41:44 1 [GPS] hasValidLocation RISING EDGE
DEBUG | 16:41:44 1 [GPS] WANT GPS=0
DEBUG | 16:41:44 1 [GPS] GPS Lock took 1, average 0
INFO  | 16:41:44 1 [GPS] Setting GPS power=0
DEBUG | 16:41:44 1 [GPS] publishing pos@661ab5c8:2, hasVal=1, Sats=9, GPSlock=1
DEBUG | 16:41:44 1 [GPS] New GPS pos@661ab5c8:3 lat=xxxx, lon=yyyy, alt=154, pdop=1.41, track=333.62, speed=0.00, sats=9
DEBUG | 16:41:44 1 [GPS] onGPSChanged() pos@661ab5c8, time=1713026504, lat=xxxx, lon=yyyy, alt=154
INFO  | 16:41:44 1 [GPS] updatePosition LOCAL pos@661ab5c8, time=1713026504, latI=xxxx, lonI=yyyy, alt=154
DEBUG | 16:41:44 1 [GPS] Setting local position: latitude=xxxx, longitude=yyyy, time=1713026504
```
